### PR TITLE
Add TestLens to CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Setup TestLens
+        uses: testlens-app/setup-testlens@v1
+
       - name: Build and test application distributions
         run: ./gradlew build jibBuildTar
 


### PR DESCRIPTION
Wires up [testlens-app/setup-testlens](https://github.com/testlens-app/setup-testlens) in the existing `Validate` workflow.

## Changes
- Add a `Setup TestLens` step (`testlens-app/setup-testlens@v1`) after `setup-gradle` and before the `./gradlew build jibBuildTar` step, per the action's Gradle setup instructions.

The TestLens GitHub App is already installed on this repo, which handles authentication automatically — no secrets required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)